### PR TITLE
Fix routing fallback to properly render NotFound page for invalid paths

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -13,6 +13,7 @@ import Signup from "./components/Signup";
 import { useEffect, useState } from "react";
 import { SignedIn } from "@clerk/clerk-react";
 import NotFound from "./components/NotFound";
+import ProtectedRouteChecker from "./components/ProtectedRouteChecker";
 import CollabEditor from "./components/secureComponents/EditorLayout";
 import CodingLobby from "./components/secureComponents/CodingLobby";
 import Playground from "./components/secureComponents/Playground";
@@ -63,28 +64,20 @@ const App = () => {
         </span>
       ))}
 
-      {/* Public Routes */}
       <Routes>
+        {/* Public routes */}
         <Route path="/" element={<WebsiteLayout />} />
         <Route path="/sso-callback" element={<SsoCallback />} />
+
         <Route path="/auth/*" element={<AuthenticationLayout />}>
           <Route path="signin" element={<Signin />} />
           <Route path="signup" element={<Signup />} />
+          <Route path="*" element={<NotFound />} />
         </Route>
-      </Routes>
 
-      {/* Protected Routes */}
-      <SignedIn>
-        <Routes>
-          <Route path="/:username/" element={<ProfileLayout />}>
-            <Route path="dashboard" element={<Dashboard />} />
-            <Route path="leaderboard" element={<Leaderboard />} />
-            <Route path="codingrooms" element={<CodingRooms />} />
-            <Route path="mcqrooms" element={<McqRooms />} />
-            <Route path="community" element={<Community />} />
-            <Route path="collaborativerooms" element={<CollaborativeRooms />} />
-          </Route>
-
+        {/* Protected routes - specific routes first */}
+        <Route element={<ProtectedRouteChecker />}>
+          {/* Other protected routes - BEFORE username route */}
           <Route path="/codingroom/:roomid/result" element={<ResultPage />} />
           <Route path="/mcqroom/:roomid/result" element={<McqResultPage />} />
           <Route path="/codingroom/:roomid/lobby" element={<CodingLobby />} />
@@ -92,11 +85,23 @@ const App = () => {
           <Route path="/room/:roomid" element={<CollabEditor />} />
           <Route path="/codingroom/:roomid/arena" element={<Playground />} />
           <Route path="/mcqrooms/:roomid/arena" element={<McqArena />} />
-          {/* <Route path="*" element={<NotFound />} /> */}
-        </Routes>
-      </SignedIn>
+
+          {/* Profile routes - AFTER specific routes */}
+          <Route path="/:username/*" element={<ProfileLayout />}>
+            <Route path="dashboard" element={<Dashboard />} />
+            <Route path="leaderboard" element={<Leaderboard />} />
+            <Route path="codingrooms" element={<CodingRooms />} />
+            <Route path="mcqrooms" element={<McqRooms />} />
+            <Route path="community" element={<Community />} />
+            <Route path="collaborativerooms" element={<CollaborativeRooms />} />
+            <Route path="*" element={<NotFound />} />
+          </Route>
+        </Route>
+
+        {/* Catch-all for undefined routes - must be last */}
+        <Route path="*" element={<NotFound />} />
+      </Routes>
     </div>
   );
 };
-
 export default App;

--- a/Frontend/src/components/ProtectedRouteChecker.jsx
+++ b/Frontend/src/components/ProtectedRouteChecker.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { SignedIn, SignedOut } from "@clerk/clerk-react";
+import { Outlet } from "react-router-dom";
+import NotFound from "./NotFound";
+
+const ProtectedRouteChecker = () => {
+  return (
+    <div>
+      <SignedIn>
+        <Outlet />
+      </SignedIn>
+
+      <SignedOut>
+        <NotFound></NotFound>
+      </SignedOut>
+    </div>
+  );
+};
+
+export default ProtectedRouteChecker;


### PR DESCRIPTION
**What was the issue?**

Navigating to unknown or invalid routes (e.g. random URLs) resulted in a blank screen instead of rendering the NotFound component.
This was caused by route matching conflicts and missing fallback handling in nested and protected routes.

**What did I change?**

Reworked the routing structure to clearly separate public and protected routes

Added proper fallback (*) routes at the correct hierarchy levels
<img width="1919" height="1079" alt="Screenshot 2025-12-23 000826" src="https://github.com/user-attachments/assets/80b5e3ea-49b4-436c-8272-44cd049500e1" />
<img width="1919" height="1079" alt="Screenshot 2025-12-23 000813" src="https://github.com/user-attachments/assets/c949d0e5-f2c0-438d-b1da-c6f18c57368c" />
<img width="1919" height="1079" alt="Screenshot 2025-12-23 000800" src="https://github.com/user-attachments/assets/b2713ad5-8f06-4869-8a98-80ed81d59da1" />

Ensured unmatched paths now consistently render the NotFound component instead of a blank screen

**Result**

Invalid routes now show a proper 404 / Not Found page

No blank screens on incorrect URLs

Routing behavior is predictable and consistent

Notes

This change improves user experience and prevents silent failures caused by unmatched routes.

Closes #<1>